### PR TITLE
Update feedback sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is currently functional, but considered a pre-release version.
 * Includes basic support for eBay digital signatures
 
 ## Notes
-* The feedback sync is currently limited to orders in the past 60 days - after which, a buyer can't leave feedback. It could be updated/removed, however, which is not currently handled.
+* The feedback sync currently fetches all feedback for a seller, updating records which already exist in the database. There is currently no link to the relevent sales record, due to eBay changing the format of legacy order IDs. A more long-term fix will be explored in a future update.
 * Postage pricing must be added manually - even if the label is purchased through eBay.
 * Fulfillment carrier name is based on the carrier chosen by the buyer. This will need to be updated manually should you use a different carrier.
 * eBay fee refunds must be entered manually.
@@ -98,6 +98,7 @@ This section lists a few notes/quirks I have encountered with the eBay API, most
 * If a tracking number is removed from an order, the returned HREF uses the tracking number '999', rather than being removed completely.
 * If eBay CS refund a buyer from their side (i.e. seller also keeps their money), the payment API will still show a payment status of 'FULLY_REFUNDED'. However, no refund details will exist.
 * finances/getTransactions supports filtering by transaction type, but is not currently open to all sellers. Could be used to automatically fetch postage label costs when it becomes available.
+* Feedback API syncs all available records on every run, due to changes to the format of legacy order IDs. So far, I have been unable to use the OrderLineItemID field, and this value is not returned in the output. Hopefully, this is a quirk of the API which will be fixed in the future.
 
 # Future Development
 While the app is working (and runs daily on my machine), there are still a few enhancements planned before I would consider it to be 'stable'.

--- a/src/ebay_sync/__main__.py
+++ b/src/ebay_sync/__main__.py
@@ -153,11 +153,9 @@ def run_sync(credentials):
             print("""[ERROR] Failed to fetch finance data for """
                   f"""order {order_id}""")
 
-    # 60 day limit for buyer to leave feedback
-    for order_id in Sale.get_order_ids(db, days=60, legacy_ids=True):
-        feedback = GetFeedback(db, credentials)
-        if records := feedback.fetch(order_id):
-            feedback.parse(records)
+    feedback = GetFeedback(db, credentials)
+    if records := feedback.fetch():
+        feedback.parse(records)
 
 def get_db_connection(credentials):
     try:

--- a/src/ebay_sync/setup/schema.sql
+++ b/src/ebay_sync/setup/schema.sql
@@ -124,9 +124,7 @@ CREATE TABLE `feedback` (
   `legacy_order_id` varchar(255) NOT NULL,
   `feedback_type` set('Negative','Neutral','Positive','Withdrawn') NOT NULL,
   `comment` varchar(512) NOT NULL,
-  PRIMARY KEY (`feedback_id`),
-  KEY `feedback_legacy_order_id` (`legacy_order_id`),
-  CONSTRAINT `feedback-legacy_order_id` FOREIGN KEY (`legacy_order_id`) REFERENCES `sale` (`legacy_order_id`) ON UPDATE CASCADE
+  PRIMARY KEY (`feedback_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE `refund` (


### PR DESCRIPTION
Updates the feedback sync.

* Removes item ID/transaction ID parameters from the feedback API request
* Generates a legacy order ID using the previous format, based on item ID/transaction ID records returned by the feedback API
* Removes the foreign key from the feedback table to allow generated legacy order IDs to be used

Not a perfect fix, but will do for the time being.